### PR TITLE
Network constructを修正

### DIFF
--- a/infrastructure/lib/constructs/Network/index.ts
+++ b/infrastructure/lib/constructs/Network/index.ts
@@ -17,16 +17,16 @@ export class Network extends Construct {
 
     // VPCを作成
     this.vpc = new ec2.Vpc(this, "Vpc", {
-      natGateways: 0,
+      //natGateways: 0,
       createInternetGateway: true,
       maxAzs: 2,
-      subnetConfiguration: [
-        {
-          cidrMask: 24,
-          name: "Public",
-          subnetType: ec2.SubnetType.PUBLIC,
-        },
-      ],
+      //subnetConfiguration: [
+      //  {
+      //    cidrMask: 24,
+      //    name: "Public",
+      //    subnetType: ec2.SubnetType.PUBLIC,
+      //  },
+      //],
     });
 
     // VPCエンドポイントを作成

--- a/infrastructure/lib/main.ts
+++ b/infrastructure/lib/main.ts
@@ -1,8 +1,7 @@
 import * as cdk from "aws-cdk-lib";
 import { Construct } from "constructs";
-//import { Network } from "./constructs/Network";
+import { Network } from "./constructs/Network";
 //import { ECS } from "./constructs/ECS";
-import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { ApplicationLoadBalancedFargateService } from "aws-cdk-lib/aws-ecs-patterns";
 import * as ecs from "aws-cdk-lib/aws-ecs";
 import { NagSuppressions } from "cdk-nag";
@@ -16,14 +15,14 @@ export class Cobol4JAwsWebStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    //const network = new Network(this, "Network");
+    const network = new Network(this, "Network");
 
     //this.ecsCluster = new ECS(this, "ECS", {
     //  vpc: network.vpc,
     //});
-    const vpc = new ec2.Vpc(this, "MyVpc", { maxAzs: 2 });
+    //const vpc = new ec2.Vpc(this, "MyVpc", { maxAzs: 2 });
     const cluster = new ecs.Cluster(this, "Cluster", {
-      vpc,
+      vpc: network.vpc,
       containerInsights: true,
     });
 
@@ -41,16 +40,16 @@ export class Cobol4JAwsWebStack extends cdk.Stack {
    */
   public addCdkNagSuppressions() {
     //this.ecsCluster.addCdkNagSuppressions(this);
-    NagSuppressions.addResourceSuppressionsByPath(
-      this,
-      "/StartCDKStack/MyVpc/Resource",
-      [
-        {
-          id: "AwsSolutions-VPC7",
-          reason: "VPC Flow Logsを作成していない",
-        },
-      ],
-    );
+    //NagSuppressions.addResourceSuppressionsByPath(
+    //  this,
+    //  "/StartCDKStack/MyVpc/Resource",
+    //  [
+    //    {
+    //      id: "AwsSolutions-VPC7",
+    //      reason: "VPC Flow Logsを作成していない",
+    //    },
+    //  ],
+    //);
     NagSuppressions.addResourceSuppressionsByPath(
       this,
       "/StartCDKStack/FargateService/LB/SecurityGroup/Resource",


### PR DESCRIPTION
# 概要

Network constructを修正し、デプロイが通るように修正

# 変更点

- vpcのサブネットとnatg gatewayに関する設定を削除し、デフォルト値を使用するように変更

# 影響範囲

デプロイが通るようになる

# テスト

なし

# 関連Issue

なし

# 関連Pull Request

なし

# その他

なし
