### PR TITLE
公衆インターネットからアクセスできないように変更

### DIFF
--- a/infrastructure/lib/constructs/ECS/index.ts
+++ b/infrastructure/lib/constructs/ECS/index.ts
@@ -40,6 +40,8 @@ export class ECS extends Construct {
         taskImageOptions: {
           image: ecs.ContainerImage.fromRegistry("amazon/amazon-ecs-sample"),
         },
+        assignPublicIp: false,
+        publicLoadBalancer: false,
       },
     );
 


### PR DESCRIPTION
# 概要
公衆インターネットからアクセスできないように変更。
今後の開発によって、ClientVPNを設定して限られた人だけがアクセスできるように設定する。

# 変更点

- 公衆インターネットからアクセスできないように変更。

# 影響範囲

公衆インターネットからアクセスできなくなる

# テスト

なし

# 関連Issue

なし

# 関連Pull Request

なし

# その他

今後の開発によって、ClientVPNを設定して限られた人だけがアクセスできるように設定する。
