### PR TITLE
opensource COBOL 4Jをビルドできるように変更

### DIFF
--- a/.github/workflows/server-app.yml
+++ b/.github/workflows/server-app.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - uses: actions/setup-java@v4
         with:
@@ -27,7 +29,7 @@ jobs:
           java-version: "17"
 
       - name: Build with Gradle
-        run: ./gradlew bootRun
+        run: ./gradlew build
 
       - name: Run tests
         if: ${{ github.event.inputs.run_tests }}

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,5 +1,3 @@
-# Ignore Gradle project-specific cache directory
 .gradle
-
-# Ignore Gradle build output directory
 build
+compiler_bin

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    id("cpp-application")
+}
+
+
+// opensource COBOL 4J のビルドタスクを追加
+tasks.register<Exec>("buildCompiler") {
+    group = "build"
+    description = "Build opensource COBOL 4J"
+
+    //// 作業ディレクトリを指定
+    workingDir = file("${project.projectDir}/opensourcecobol4j/")
+
+    // 入力ファイルと出力ファイルを指定
+    inputs.files(fileTree("${project.projectDir}/opensourcecobol4j"))
+    outputs.file("${project.projectDir}/compiler_bin/lib/opensourcecobol4j/libcobj.jar")
+
+    // 実行コマンドを指定
+    commandLine("sh", "-c", """
+        mkdir -p ${project.projectDir}/compiler_bin &&
+        ./configure --prefix=${project.projectDir}/compiler_bin &&
+        make &&
+        make install
+    """.trimIndent())
+}
+
+tasks.named("build").configure {
+    dependsOn("buildCompiler")
+}


### PR DESCRIPTION
# 概要

server/ディレクトリで、gradlew buildを実行するとopensource COBOL 4Jをビルドできるように変更

# 変更点

- server/ディレクトリで、gradlew buildを実行するとopensource COBOL 4Jをビルドできるように変更
- GitHub Actionにおいてserver/ディレクトリで./gradlw buildを実行するように変更

# 影響範囲

AWS環境には影響なし

# テスト

なし

# 関連Issue

なし

# 関連Pull Request

なし

# その他

なし
