### PR TITLE
COBOLソースコードを追加してコンパイル

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,3 +1,4 @@
 .gradle
 build
 compiler_bin
+cobol_converted

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -2,18 +2,21 @@ plugins {
     id("cpp-application")
 }
 
-
 // opensource COBOL 4J のビルドタスクを追加
 tasks.register<Exec>("buildCompiler") {
     group = "build"
     description = "Build opensource COBOL 4J"
 
-    //// 作業ディレクトリを指定
+    // 作業ディレクトリを指定
     workingDir = file("${project.projectDir}/opensourcecobol4j/")
 
     // 入力ファイルと出力ファイルを指定
     inputs.files(fileTree("${project.projectDir}/opensourcecobol4j"))
-    outputs.file("${project.projectDir}/compiler_bin/lib/opensourcecobol4j/libcobj.jar")
+    outputs.files(
+        file("${project.projectDir}/compiler_bin/lib/opensourcecobol4j/libcobj.jar"),
+        file("${project.projectDir}/compiler_bin/bin/cobj"),
+        file("${project.projectDir}/compiler_bin/bin/cobj-api"),
+    )
 
     // 実行コマンドを指定
     commandLine("sh", "-c", """
@@ -24,6 +27,34 @@ tasks.register<Exec>("buildCompiler") {
     """.trimIndent())
 }
 
-tasks.named("build").configure {
+tasks.register<Exec>("buildCobol") {
     dependsOn("buildCompiler")
+
+    group = "build"
+    description = "Build COBOL source files"
+
+    // 作業ディレクトリを指定
+    workingDir = file("${project.projectDir}/cobol/")
+
+    inputs.files(
+        file("${project.projectDir}/compiler_bin/lib/opensourcecobol4j/libcobj.jar"),
+        file("${project.projectDir}/compiler_bin/bin/cobj"),
+        file("${project.projectDir}/compiler_bin/bin/cobj-api"),
+        fileTree("${project.projectDir}/cobol"),
+    )
+
+    outputs.files(
+        fileTree("${project.projectDir}/cobol_converted"),
+    )
+
+    commandLine("sh", "-c", """
+        mkdir -p ${project.projectDir}/cobol_converted &&
+        ${project.projectDir}/compiler_bin/bin/cobj -info-json-dir=${project.projectDir}/cobol_converted -C *.cbl &&
+        mv *.java ${project.projectDir}/cobol_converted &&
+        CLASSPATH=:${project.projectDir}/compiler_bin/lib/opensourcecobol4j/libcobj.jar ${project.projectDir}/compiler_bin/bin/cobj-api --output-dir=${project.projectDir}/cobol_converted ${project.projectDir}/cobol_converted/*.json
+    """)
+}
+
+tasks.named("build").configure {
+    dependsOn("buildCobol")
 }

--- a/server/cobol/sample.cbl
+++ b/server/cobol/sample.cbl
@@ -1,0 +1,19 @@
+       IDENTIFICATION          DIVISION.
+       PROGRAM-ID.             sample.
+       ENVIRONMENT             DIVISION.
+       CONFIGURATION           SECTION.
+       DATA                    DIVISION.
+       WORKING-STORAGE         SECTION.
+       LINKAGE                 SECTION.
+       01  DATA1               PIC 9(09).
+       01  DATA2               PIC 9(09).
+       01  DATA3               PIC 9(09).
+       01  SUM-DATA            PIC 9(09).
+       PROCEDURE               DIVISION
+                               USING  DATA1,
+                                      DATA2,
+                                      DATA3,
+                                      SUM-DATA.
+       MAIN-SECTION.
+           ADD DATA1 DATA2 DATA3 TO SUM-DATA.
+       GOBACK.


### PR DESCRIPTION
# 概要

COBOLソースコードを追加してコンパイルできるようにした

# 変更点

- server/cobolにCOBOLソースコードを追加した。
- serverのgradleの設定を変更して、COBOLソースコードのJava変換とSpring boot用コードの生成を実行できるようにした

# 影響範囲

AWS環境に影響はない

# テスト

なし

# 関連Issue

なし

# 関連Pull Request

なし

# その他

今のビルドでは、コンパイラに変更がなくても必ずコンパイラのビルドから始まる。
この課題は今後解決する。
参考: https://tomgregory.com/gradle/gradle-task-inputs-and-outputs/
