### PR TITLE
gradleの依存関係を修正

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -1,60 +1,60 @@
+import java.io.ByteArrayOutputStream
+
 plugins {
     id("cpp-application")
 }
 
+// Git管理下にあるファイルを取得する関数
+
+fun getGitManagedFiles(dir: File): FileTree {
+    val output = ByteArrayOutputStream()
+    project.exec {
+        workingDir = dir
+        commandLine("git", "ls-files", "-z")
+        standardOutput = output
+    }
+    val gitFiles = output.toString().split("\u0000")
+    return fileTree(dir) {
+        include(gitFiles)
+    }
+}
+
 // opensource COBOL 4J のビルドタスクを追加
-tasks.register<Exec>("buildCompiler") {
+tasks.register("buildCobol") {
     group = "build"
     description = "Build opensource COBOL 4J"
 
-    // 作業ディレクトリを指定
-    workingDir = file("${project.projectDir}/opensourcecobol4j/")
+    val opensourceCobol4jDir = file("${project.projectDir}/opensourcecobol4j/")
 
-    // 入力ファイルと出力ファイルを指定
-    inputs.files(fileTree("${project.projectDir}/opensourcecobol4j"))
-    outputs.files(
-        file("${project.projectDir}/compiler_bin/lib/opensourcecobol4j/libcobj.jar"),
-        file("${project.projectDir}/compiler_bin/bin/cobj"),
-        file("${project.projectDir}/compiler_bin/bin/cobj-api"),
-    )
+    // Git管理下にあるファイルのみを入力として指定
+    inputs.files(getGitManagedFiles(opensourceCobol4jDir)).skipWhenEmpty()
+
+    // 出力ファイルを指定
+    outputs.file(file("${project.projectDir}/compiler_bin/lib/opensourcecobol4j/libcobj.jar"))
+    outputs.file(file("${project.projectDir}/compiler_bin/bin/cobj"))
+    outputs.file(file("${project.projectDir}/compiler_bin/bin/cobj-api"))
+
+    // up-to-dateチェックをカスタマイズ
+    outputs.upToDateWhen {
+        file("${project.projectDir}/compiler_bin/lib/opensourcecobol4j/libcobj.jar").exists() &&
+        file("${project.projectDir}/compiler_bin/bin/cobj").exists() &&
+        file("${project.projectDir}/compiler_bin/bin/cobj-api").exists()
+    }
 
     // 実行コマンドを指定
-    commandLine("sh", "-c", """
-        mkdir -p ${project.projectDir}/compiler_bin &&
-        ./configure --prefix=${project.projectDir}/compiler_bin &&
-        make &&
-        make install
-    """.trimIndent())
+    doLast {
+        exec {
+            workingDir(opensourceCobol4jDir)
+            commandLine("sh", "-c", """
+                mkdir -p ${project.projectDir}/compiler_bin &&
+                ./configure --prefix=${project.projectDir}/compiler_bin &&
+                make &&
+                make install
+            """.trimIndent())
+        }
+    }
 }
 
-tasks.register<Exec>("buildCobol") {
-    dependsOn("buildCompiler")
-
-    group = "build"
-    description = "Build COBOL source files"
-
-    // 作業ディレクトリを指定
-    workingDir = file("${project.projectDir}/cobol/")
-
-    inputs.files(
-        file("${project.projectDir}/compiler_bin/lib/opensourcecobol4j/libcobj.jar"),
-        file("${project.projectDir}/compiler_bin/bin/cobj"),
-        file("${project.projectDir}/compiler_bin/bin/cobj-api"),
-        fileTree("${project.projectDir}/cobol"),
-    )
-
-    outputs.files(
-        fileTree("${project.projectDir}/cobol_converted"),
-    )
-
-    commandLine("sh", "-c", """
-        mkdir -p ${project.projectDir}/cobol_converted &&
-        ${project.projectDir}/compiler_bin/bin/cobj -info-json-dir=${project.projectDir}/cobol_converted -C *.cbl &&
-        mv *.java ${project.projectDir}/cobol_converted &&
-        CLASSPATH=:${project.projectDir}/compiler_bin/lib/opensourcecobol4j/libcobj.jar ${project.projectDir}/compiler_bin/bin/cobj-api --output-dir=${project.projectDir}/cobol_converted ${project.projectDir}/cobol_converted/*.json
-    """)
-}
-
-tasks.named("build").configure {
+tasks.named("build") {
     dependsOn("buildCobol")
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -1,9 +1,5 @@
 import java.io.ByteArrayOutputStream
 
-plugins {
-    id("cpp-application")
-}
-
 // Git管理下にあるファイルを取得する関数
 fun getGitManagedFiles(dir: File): FileTree {
     val output = ByteArrayOutputStream()
@@ -44,6 +40,7 @@ tasks.register<Exec>("buildCompiler") {
 }
 
 tasks.register<Exec>("buildCobol") {
+    dependsOn("buildCompiler")
 
     group = "build"
     description = "Build COBOL source files"
@@ -70,6 +67,9 @@ tasks.register<Exec>("buildCobol") {
     """)
 }
 
-tasks.named("build").configure {
+// buildタスクを明示的に定義
+tasks.register("build") {
+    group = "build"
+    description = "Builds the project"
     dependsOn("buildCobol")
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 }
 
 // Git管理下にあるファイルを取得する関数
-
 fun getGitManagedFiles(dir: File): FileTree {
     val output = ByteArrayOutputStream()
     project.exec {
@@ -20,41 +19,57 @@ fun getGitManagedFiles(dir: File): FileTree {
 }
 
 // opensource COBOL 4J のビルドタスクを追加
-tasks.register("buildCobol") {
+tasks.register<Exec>("buildCompiler") {
     group = "build"
     description = "Build opensource COBOL 4J"
 
-    val opensourceCobol4jDir = file("${project.projectDir}/opensourcecobol4j/")
+    // 作業ディレクトリを指定
+    workingDir = file("${project.projectDir}/opensourcecobol4j/")
 
-    // Git管理下にあるファイルのみを入力として指定
-    inputs.files(getGitManagedFiles(opensourceCobol4jDir)).skipWhenEmpty()
-
-    // 出力ファイルを指定
-    outputs.file(file("${project.projectDir}/compiler_bin/lib/opensourcecobol4j/libcobj.jar"))
-    outputs.file(file("${project.projectDir}/compiler_bin/bin/cobj"))
-    outputs.file(file("${project.projectDir}/compiler_bin/bin/cobj-api"))
-
-    // up-to-dateチェックをカスタマイズ
-    outputs.upToDateWhen {
-        file("${project.projectDir}/compiler_bin/lib/opensourcecobol4j/libcobj.jar").exists() &&
-        file("${project.projectDir}/compiler_bin/bin/cobj").exists() &&
-        file("${project.projectDir}/compiler_bin/bin/cobj-api").exists()
-    }
+    // 入力ファイルと出力ファイルを指定
+    inputs.files(getGitManagedFiles(file("${project.projectDir}/opensourcecobol4j/")))
+    outputs.files(
+        file("${project.projectDir}/compiler_bin/lib/opensourcecobol4j/libcobj.jar"),
+        file("${project.projectDir}/compiler_bin/bin/cobj"),
+        file("${project.projectDir}/compiler_bin/bin/cobj-api"),
+    )
 
     // 実行コマンドを指定
-    doLast {
-        exec {
-            workingDir(opensourceCobol4jDir)
-            commandLine("sh", "-c", """
-                mkdir -p ${project.projectDir}/compiler_bin &&
-                ./configure --prefix=${project.projectDir}/compiler_bin &&
-                make &&
-                make install
-            """.trimIndent())
-        }
-    }
+    commandLine("sh", "-c", """
+        mkdir -p ${project.projectDir}/compiler_bin &&
+        ./configure --prefix=${project.projectDir}/compiler_bin &&
+        make &&
+        make install
+    """.trimIndent())
 }
 
-tasks.named("build") {
+tasks.register<Exec>("buildCobol") {
+
+    group = "build"
+    description = "Build COBOL source files"
+
+    // 作業ディレクトリを指定
+    workingDir = file("${project.projectDir}/cobol/")
+
+    inputs.files(
+        file("${project.projectDir}/compiler_bin/lib/opensourcecobol4j/libcobj.jar"),
+        file("${project.projectDir}/compiler_bin/bin/cobj"),
+        file("${project.projectDir}/compiler_bin/bin/cobj-api"),
+        fileTree("${project.projectDir}/cobol"),
+    )
+
+    outputs.files(
+        fileTree("${project.projectDir}/cobol_converted"),
+    )
+
+    commandLine("sh", "-c", """
+        mkdir -p ${project.projectDir}/cobol_converted &&
+        ${project.projectDir}/compiler_bin/bin/cobj -info-json-dir=${project.projectDir}/cobol_converted -C *.cbl &&
+        mv *.java ${project.projectDir}/cobol_converted &&
+        CLASSPATH=:${project.projectDir}/compiler_bin/lib/opensourcecobol4j/libcobj.jar ${project.projectDir}/compiler_bin/bin/cobj-api --output-dir=${project.projectDir}/cobol_converted ${project.projectDir}/cobol_converted/*.json
+    """)
+}
+
+tasks.named("build").configure {
     dependsOn("buildCobol")
 }


### PR DESCRIPTION
# 概要

#40を解決するため、gradleの依存関係を修正した

# 変更点

- server/build.gradle.ktsを変更
  - 以前はopensourcecobol4j/内でビルドしたバイナリによって、ビルドのたびにopensourcecobol4jディレクトリが更新されたと判定されていた。opensourcecobol4jディレクトリでなくopensourcecobol4j/でgitにより管理されているファイルに依存するように変更することで解決した。

# 影響範囲

なし

# テスト

なし

# 関連Issue

#40

# 関連Pull Request

なし

# その他

なし