### PR TITLE
生成されるJavaファイルやJSONファイルのパスを変更

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -2,6 +2,7 @@
 build
 compiler_bin
 cobol_converted
+json
 app/src/main/java/cobol4j/aws/web/sample.java
 app/src/main/java/cobol4j/aws/web/sampleController.java
 app/src/main/java/cobol4j/aws/web/sampleRecord.java

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -2,3 +2,6 @@
 build
 compiler_bin
 cobol_converted
+app/src/main/java/cobol4j/aws/web/sample.java
+app/src/main/java/cobol4j/aws/web/sampleController.java
+app/src/main/java/cobol4j/aws/web/sampleRecord.java

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -55,17 +55,21 @@ tasks.register<Exec>("buildCobol") {
         fileTree("${project.projectDir}/cobol"),
     )
 
+    val javaDir = "${project.projectDir}/app/src/main/java/cobol4j/aws/web/"
+    val jsonDir = "${project.projectDir}/json"
+
     outputs.files(
-        file("${project.projectDir}/app/src/main/java/cobol4j/aws/web/sample.java"),
-        file("${project.projectDir}/app/src/main/java/cobol4j/aws/web/sampleController.java"),
-        file("${project.projectDir}/app/src/main/java/cobol4j/aws/web/sampleRecord.java"),
+        file("${javaDir}/sample.java"),
+        file("${javaDir}/sampleController.java"),
+        file("${javaDir}/sampleRecord.java"),
+        file("${jsonDir}/info_sample.json"),
     )
 
     commandLine("sh", "-c", """
-        ${project.projectDir}/compiler_bin/bin/cobj -info-json-dir=${project.projectDir}/app/src/main/java/cobol4j/aws/web/ -C *.cbl &&
-        mv *.java ${project.projectDir}/app/src/main/java/cobol4j/aws/web/ &&
-        CLASSPATH=:${project.projectDir}/compiler_bin/lib/opensourcecobol4j/libcobj.jar ${project.projectDir}/compiler_bin/bin/cobj-api --output-dir=${project.projectDir}/app/src/main/java/cobol4j/aws/web/ ${project.projectDir}/app/src/main/java/cobol4j/aws/web//info_sample.json &&
-        rm ${project.projectDir}/app/src/main/java/cobol4j/aws/web/info_sample.json
+        mkdir -p ${jsonDir} &&
+        ${project.projectDir}/compiler_bin/bin/cobj -info-json-dir=${jsonDir} -C *.cbl &&
+        mv *.java ${javaDir} &&
+        CLASSPATH=:${project.projectDir}/compiler_bin/lib/opensourcecobol4j/libcobj.jar ${project.projectDir}/compiler_bin/bin/cobj-api --output-dir=${project.projectDir}/app/src/main/java/cobol4j/aws/web/ ${jsonDir}/info_sample.json
     """)
 }
 

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -56,14 +56,16 @@ tasks.register<Exec>("buildCobol") {
     )
 
     outputs.files(
-        fileTree("${project.projectDir}/cobol_converted"),
+        file("${project.projectDir}/app/src/main/java/cobol4j/aws/web/sample.java"),
+        file("${project.projectDir}/app/src/main/java/cobol4j/aws/web/sampleController.java"),
+        file("${project.projectDir}/app/src/main/java/cobol4j/aws/web/sampleRecord.java"),
     )
 
     commandLine("sh", "-c", """
-        mkdir -p ${project.projectDir}/cobol_converted &&
-        ${project.projectDir}/compiler_bin/bin/cobj -info-json-dir=${project.projectDir}/cobol_converted -C *.cbl &&
-        mv *.java ${project.projectDir}/cobol_converted &&
-        CLASSPATH=:${project.projectDir}/compiler_bin/lib/opensourcecobol4j/libcobj.jar ${project.projectDir}/compiler_bin/bin/cobj-api --output-dir=${project.projectDir}/cobol_converted ${project.projectDir}/cobol_converted/*.json
+        ${project.projectDir}/compiler_bin/bin/cobj -info-json-dir=${project.projectDir}/app/src/main/java/cobol4j/aws/web/ -C *.cbl &&
+        mv *.java ${project.projectDir}/app/src/main/java/cobol4j/aws/web/ &&
+        CLASSPATH=:${project.projectDir}/compiler_bin/lib/opensourcecobol4j/libcobj.jar ${project.projectDir}/compiler_bin/bin/cobj-api --output-dir=${project.projectDir}/app/src/main/java/cobol4j/aws/web/ ${project.projectDir}/app/src/main/java/cobol4j/aws/web//info_sample.json &&
+        rm ${project.projectDir}/app/src/main/java/cobol4j/aws/web/info_sample.json
     """)
 }
 

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -14,26 +14,33 @@ fun getGitManagedFiles(dir: File): FileTree {
     }
 }
 
+val compilerBinDir = "${project.projectDir}/compiler_bin"
+val libcobjJar = "${compilerBinDir}/lib/opensourcecobol4j/libcobj.jar"
+val cobj = "${compilerBinDir}/bin/cobj"
+val cobjApi = "${compilerBinDir}/bin/cobj-api"
+
 // opensource COBOL 4J のビルドタスクを追加
 tasks.register<Exec>("buildCompiler") {
     group = "build"
     description = "Build opensource COBOL 4J"
 
     // 作業ディレクトリを指定
-    workingDir = file("${project.projectDir}/opensourcecobol4j/")
+    val opensourcecobol4jDir = file("${project.projectDir}/opensourcecobol4j/")
+
+    workingDir = opensourcecobol4jDir
 
     // 入力ファイルと出力ファイルを指定
-    inputs.files(getGitManagedFiles(file("${project.projectDir}/opensourcecobol4j/")))
+    inputs.files(getGitManagedFiles(opensourcecobol4jDir))
     outputs.files(
-        file("${project.projectDir}/compiler_bin/lib/opensourcecobol4j/libcobj.jar"),
-        file("${project.projectDir}/compiler_bin/bin/cobj"),
-        file("${project.projectDir}/compiler_bin/bin/cobj-api"),
+        file(libcobjJar),
+        file(cobj),
+        file(cobjApi),
     )
 
     // 実行コマンドを指定
     commandLine("sh", "-c", """
-        mkdir -p ${project.projectDir}/compiler_bin &&
-        ./configure --prefix=${project.projectDir}/compiler_bin &&
+        mkdir -p ${compilerBinDir} &&
+        ./configure --prefix=${compilerBinDir} &&
         make &&
         make install
     """.trimIndent())
@@ -49,9 +56,9 @@ tasks.register<Exec>("buildCobol") {
     workingDir = file("${project.projectDir}/cobol/")
 
     inputs.files(
-        file("${project.projectDir}/compiler_bin/lib/opensourcecobol4j/libcobj.jar"),
-        file("${project.projectDir}/compiler_bin/bin/cobj"),
-        file("${project.projectDir}/compiler_bin/bin/cobj-api"),
+        file(libcobjJar),
+        file(cobj),
+        file(cobjApi),
         fileTree("${project.projectDir}/cobol"),
     )
 

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -29,8 +29,10 @@ tasks.register<Exec>("buildCompiler") {
 
     workingDir = opensourcecobol4jDir
 
-    // 入力ファイルと出力ファイルを指定
+    // 入力ファイルを指定
     inputs.files(getGitManagedFiles(opensourcecobol4jDir))
+
+    // 出力ファイルを指定
     outputs.files(
         file(libcobjJar),
         file(cobj),
@@ -52,19 +54,22 @@ tasks.register<Exec>("buildCobol") {
     group = "build"
     description = "Build COBOL source files"
 
-    // 作業ディレクトリを指定
-    workingDir = file("${project.projectDir}/cobol/")
+    val cobolDir = "${project.projectDir}/cobol/"
+    val javaDir = "${project.projectDir}/app/src/main/java/cobol4j/aws/web/"
+    val jsonDir = "${project.projectDir}/json"
 
+    // 作業ディレクトリを指定
+    workingDir = file(cobolDir)
+
+    // 入力ファイルと出力ファイルを指定
     inputs.files(
         file(libcobjJar),
         file(cobj),
         file(cobjApi),
-        fileTree("${project.projectDir}/cobol"),
+        fileTree(cobolDir),
     )
 
-    val javaDir = "${project.projectDir}/app/src/main/java/cobol4j/aws/web/"
-    val jsonDir = "${project.projectDir}/json"
-
+    // 出力ファイルを指定
     outputs.files(
         file("${javaDir}/sample.java"),
         file("${javaDir}/sampleController.java"),
@@ -74,9 +79,9 @@ tasks.register<Exec>("buildCobol") {
 
     commandLine("sh", "-c", """
         mkdir -p ${jsonDir} &&
-        ${project.projectDir}/compiler_bin/bin/cobj -info-json-dir=${jsonDir} -C *.cbl &&
+        ${cobj} -info-json-dir=${jsonDir} -C *.cbl &&
         mv *.java ${javaDir} &&
-        CLASSPATH=:${project.projectDir}/compiler_bin/lib/opensourcecobol4j/libcobj.jar ${project.projectDir}/compiler_bin/bin/cobj-api --output-dir=${project.projectDir}/app/src/main/java/cobol4j/aws/web/ ${jsonDir}/info_sample.json
+        CLASSPATH=:${libcobjJar} ${cobjApi} --output-dir=${javaDir} ${jsonDir}/info_sample.json
     """)
 }
 

--- a/server/settings.gradle.kts
+++ b/server/settings.gradle.kts
@@ -11,4 +11,4 @@ plugins {
 }
 
 rootProject.name = "cobol4j-aws-web"
-include("app")
+//include("app")


### PR DESCRIPTION
# 概要

生成されるJavaファイルやJSONファイルのパスを変更した

# 変更点

- 生成されるJavaファイルのパスを`server/app/src/main/java/cobol4j/aws/web/`に変更
- 生成されるJavaファイルのパスを`server/json`に変更
- `build.gradle.kts`内の変数を追加してリファクタリング

# 影響範囲

生成されるファイルのパスが変更された

# テスト

なし

# 関連Issue

なし

# 関連Pull Request

なし

# その他

なし