### PR TITLE
Dockerイメージのビルド処理を追加

### DIFF
--- a/.github/workflows/server-app.yml
+++ b/.github/workflows/server-app.yml
@@ -29,7 +29,7 @@ jobs:
           java-version: "17"
 
       - name: Build with Gradle
-        run: ./gradlew bootJar
+        run: ./gradlew buildDockerImage
 
       #- name: Run tests
       #  if: ${{ github.event.inputs.run_tests }}

--- a/server/app/Dockerfile
+++ b/server/app/Dockerfile
@@ -1,0 +1,15 @@
+# ベースイメージを指定
+FROM openjdk:17-jdk-alpine
+
+# 作業ディレクトリを作成
+WORKDIR /app
+
+# 依存関係のコピー
+COPY lib /app/lib
+
+# アプリケーションのJARファイルをコピー
+ARG JAR_FILE=build/libs/app.jar
+COPY ${JAR_FILE} app.jar
+
+# アプリケーションを実行
+ENTRYPOINT ["java", "-cp", "app.jar:lib/*", "org.springframework.boot.loader.JarLauncher"]

--- a/server/app/build.gradle.kts
+++ b/server/app/build.gradle.kts
@@ -15,6 +15,7 @@ val javaDir = "${project.projectDir}/src/main/java/cobol4j/aws/web/"
 val libDir = "${project.projectDir}/lib"
 val libLibcobjJar = "${libDir}/libcobj.jar"
 val javaPackage = "cobol4j.aws.web"
+val dockerImageTag = "cobol4j-aws-web:latest"
 
 plugins {
     // Apply the application plugin to add support for building a CLI application in Java.
@@ -158,7 +159,18 @@ tasks.register<Exec>("buildCobol") {
     """)
 }
 
+
 tasks.named("compileJava") {
     dependsOn("buildCobol")
     dependsOn("moveLibcobjJar")
+}
+
+tasks.register<Exec>("buildDockerImage") {
+    dependsOn("compileJava")
+
+    inputs.files(
+        file("Dockerfile"),
+    )
+
+    commandLine("sh", "-c", "docker build -t ${dockerImageTag} .")
 }

--- a/server/app/build.gradle.kts
+++ b/server/app/build.gradle.kts
@@ -165,8 +165,12 @@ tasks.named("compileJava") {
     dependsOn("moveLibcobjJar")
 }
 
-tasks.register<Exec>("buildDockerImage") {
+tasks.named("bootJar") {
     dependsOn("compileJava")
+}
+
+tasks.register<Exec>("buildDockerImage") {
+    dependsOn("bootJar")
 
     inputs.files(
         file("Dockerfile"),


### PR DESCRIPTION
# 概要

server/ディレクトリで./gradlew buildDockerImageを実行することでDockerイメージをビルドできるようにした。

# 変更点

変更点や修正箇所を箇条書きで記載する

- server/ディレクトリで./gradlew buildDockerImageを実行することでDockerイメージをビルドできるようにした
- CIを変更して、Dockerイメージのビルドが実行されるように変更した

# 影響範囲

なし

# テスト

なし

# 関連Issue

なし

# 関連Pull Request

なし

# その他

ビルドしてできあがるDockerイメージはまだ使用できない。
今後の開発で使えるようにする。

