### PR TITLE
gradle向けのdependabotの設定を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/infrastructure"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "gradle"
+    directory: "/server"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
# 概要

gradle向けのdependabotの設定を追加

# 変更点

- gradle向けのdependabotの設定を追加

# 影響範囲

dependabotがgradleの依存関係を扱うようになる

# テスト

なし

# 関連Issue

なし

# 関連Pull Request

なし

# その他

なし
