### PR TITLE
Dockerイメージのデプロイ

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - uses: actions/setup-node@v4
         with:
@@ -31,8 +33,15 @@ jobs:
           cache: "npm"
           cache-dependency-path: "infrastructure/package-lock.json"
 
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
       - name: Deploy
-        working-directory: ./infrastructure
         run: |
+          cd server
+          ./gradlew buildDockerImageTarball
+          cd ../infrastructure
           npm ci
           npx cdk deploy --require-approval never -O output.js

--- a/.github/workflows/post-cdk-diff.yml
+++ b/.github/workflows/post-cdk-diff.yml
@@ -12,6 +12,7 @@ env:
   ROLE_ARN: arn:aws:iam::${{ secrets.AWS_ID }}:role/${{ secrets.ROLE_NAME }}
   SESSION_NAME: gh-oidc-${{ github.run_id }}-${{ github.run_attempt }}
   AWS_CLIENT_VPN_CERTIFICATE_ARN: ${{ secrets.AWS_CLIENT_VPN_CERTIFICATE_ARN }}
+  USE_MOCK_DOCKER_IMAGE: "true"
 
 jobs:
   cdk-diff:

--- a/.github/workflows/server-app.yml
+++ b/.github/workflows/server-app.yml
@@ -29,7 +29,7 @@ jobs:
           java-version: "17"
 
       - name: Build with Gradle
-        run: ./gradlew buildDockerImage
+        run: ./gradlew buildDockerImageTarball
 
       #- name: Run tests
       #  if: ${{ github.event.inputs.run_tests }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ permissions:
 
 env:
   AWS_CLIENT_VPN_CERTIFICATE_ARN: ${{ secrets.AWS_CLIENT_VPN_CERTIFICATE_ARN }}
+  USE_MOCK_DOCKER_IMAGE: "true"
 
 jobs:
   test:
@@ -14,23 +15,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
           cache: "npm"
           cache-dependency-path: "infrastructure/package-lock.json"
-
-      - uses: actions/setup-java@v4
-        with:
-          distribution: "temurin"
-          java-version: "17"
-
-      - name: Build a Docker image
-        working-directory: ./server
-        run: ./gradlew buildDockerImageTarball
 
       - run: npm ci
         working-directory: ./infrastructure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,23 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
           cache: "npm"
           cache-dependency-path: "infrastructure/package-lock.json"
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Build a Docker image
+        working-directory: ./server
+        run: ./gradlew buildDockerImageTarball
 
       - run: npm ci
         working-directory: ./infrastructure

--- a/infrastructure/lib/constructs/ECS/index.ts
+++ b/infrastructure/lib/constructs/ECS/index.ts
@@ -50,8 +50,8 @@ export class ECS extends Construct {
           image: ecs.ContainerImage.fromTarball(tarballPath),
           containerPort: 8080,
         },
-        assignPublicIp: false,
-        publicLoadBalancer: false,
+        assignPublicIp: true,
+        publicLoadBalancer: true,
       },
     );
 

--- a/infrastructure/lib/constructs/ECS/index.ts
+++ b/infrastructure/lib/constructs/ECS/index.ts
@@ -6,6 +6,7 @@ import { ApplicationLoadBalancedFargateService } from "aws-cdk-lib/aws-ecs-patte
 import { StackProps } from "aws-cdk-lib";
 //import * as s3 from "aws-cdk-lib/aws-s3";
 import { NagSuppressions } from "cdk-nag";
+import * as path from "path";
 
 /**
  * ECSのプロパティ
@@ -30,6 +31,14 @@ export class ECS extends Construct {
       vpc: props.vpc,
       containerInsights: true,
     });
+    // カレントディレクトリの絶対パスを取得
+    const currentDir = path.resolve(__dirname);
+
+    // tarファイルの絶対パスを計算
+    const tarballPath = path.join(
+      currentDir,
+      "../../../../server/app/cobol4j-aws-web.tar",
+    );
 
     // Fargateサービスを作成
     const albEcsService = new ApplicationLoadBalancedFargateService(
@@ -38,7 +47,8 @@ export class ECS extends Construct {
       {
         cluster,
         taskImageOptions: {
-          image: ecs.ContainerImage.fromRegistry("amazon/amazon-ecs-sample"),
+          image: ecs.ContainerImage.fromTarball(tarballPath),
+          containerPort: 8080,
         },
         assignPublicIp: false,
         publicLoadBalancer: false,
@@ -69,6 +79,16 @@ export class ECS extends Construct {
         {
           id: "AwsSolutions-ELB2",
           reason: "一時的にALBのアクセスログを無効化",
+        },
+      ],
+    );
+    NagSuppressions.addResourceSuppressionsByPath(
+      parentStack,
+      "/StartCDKStack/ECS/Service/TaskDef/ExecutionRole/DefaultPolicy/Resource",
+      [
+        {
+          id: "AwsSolutions-IAM5",
+          reason: "IAMに関するNAGのチェックを抑制",
         },
       ],
     );

--- a/infrastructure/lib/constructs/ECS/index.ts
+++ b/infrastructure/lib/constructs/ECS/index.ts
@@ -40,6 +40,11 @@ export class ECS extends Construct {
       "../../../../server/app/cobol4j-aws-web.tar",
     );
 
+    const image =
+      process.env.USE_MOCK_DOCKER_IMAGE === "true"
+        ? ecs.ContainerImage.fromRegistry("amazon/amazon-ecs-sample")
+        : ecs.ContainerImage.fromTarball(tarballPath);
+
     // Fargateサービスを作成
     const albEcsService = new ApplicationLoadBalancedFargateService(
       this,
@@ -47,7 +52,7 @@ export class ECS extends Construct {
       {
         cluster,
         taskImageOptions: {
-          image: ecs.ContainerImage.fromTarball(tarballPath),
+          image: image,
           containerPort: 8080,
         },
         assignPublicIp: true,

--- a/infrastructure/lib/constructs/Network/index.ts
+++ b/infrastructure/lib/constructs/Network/index.ts
@@ -46,20 +46,20 @@ export class Network extends Construct {
     });
 
     // Client VPNエンドポイントを作成
-    const certificateArn = process.env.AWS_CLIENT_VPN_CERTIFICATE_ARN;
-    if (!certificateArn) {
-      throw new Error(
-        "environment variable AWS_CLIENT_VPN_CERTIFICATE_ARN is required",
-      );
-    }
+    //const certificateArn = process.env.AWS_CLIENT_VPN_CERTIFICATE_ARN;
+    //if (!certificateArn) {
+    //  throw new Error(
+    //    "environment variable AWS_CLIENT_VPN_CERTIFICATE_ARN is required",
+    //  );
+    //}
 
-    new ec2.ClientVpnEndpoint(this, "ClientVpnEndpoint", {
-      vpc: this.vpc,
-      cidr: "10.100.0.0/16",
-      serverCertificateArn: certificateArn,
-      clientCertificateArn: certificateArn,
-      splitTunnel: true,
-      dnsServers: ["10.0.0.2"],
-    });
+    //new ec2.ClientVpnEndpoint(this, "ClientVpnEndpoint", {
+    //  vpc: this.vpc,
+    //  cidr: "10.100.0.0/16",
+    //  serverCertificateArn: certificateArn,
+    //  clientCertificateArn: certificateArn,
+    //  splitTunnel: true,
+    //  dnsServers: ["10.0.0.2"],
+    //});
   }
 }

--- a/server/app/.gitignore
+++ b/server/app/.gitignore
@@ -1,2 +1,3 @@
 src/main/java/cobol4j/aws/web/sample*.java
 lib/
+*.tar

--- a/server/app/Dockerfile
+++ b/server/app/Dockerfile
@@ -5,11 +5,11 @@ FROM openjdk:17-jdk-alpine
 WORKDIR /app
 
 # 依存関係のコピー
-COPY lib /app/lib
+COPY lib /app
 
 # アプリケーションのJARファイルをコピー
 ARG JAR_FILE=build/libs/app.jar
 COPY ${JAR_FILE} app.jar
 
 # アプリケーションを実行
-ENTRYPOINT ["java", "-cp", "app.jar:lib/*", "org.springframework.boot.loader.JarLauncher"]
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/server/app/build.gradle.kts
+++ b/server/app/build.gradle.kts
@@ -16,6 +16,7 @@ val libDir = "${project.projectDir}/lib"
 val libLibcobjJar = "${libDir}/libcobj.jar"
 val javaPackage = "cobol4j.aws.web"
 val dockerImageTag = "cobol4j-aws-web:latest"
+val dockerImageTarball = "cobol4j-aws-web.tar"
 
 plugins {
     // Apply the application plugin to add support for building a CLI application in Java.
@@ -177,4 +178,14 @@ tasks.register<Exec>("buildDockerImage") {
     )
 
     commandLine("sh", "-c", "docker build -t ${dockerImageTag} .")
+}
+
+tasks.register<Exec>("buildDockerImageTarball") {
+    dependsOn("buildDockerImage")
+
+    outputs.files(
+        file(dockerImageTarball),
+    )
+
+    commandLine("sh", "-c", "docker save -o ${dockerImageTarball} ${dockerImageTag}")
 }


### PR DESCRIPTION
# 概要

動作するDockerイメージを作成し、ECSにデプロイする

# 変更点

- Dockerfileを修正しWeb Applicationが動くように変更
- ECSがDockerfileでビルドしたイメージを利用するように変更
- ClientVPN Endpointを廃止
- ALBをpublicに変更

# 影響範囲

Web Applicationが動作するようになる。
Client VPNが利用不能になる

# テスト

Dockerイメージが動作することはローカルで確認済み

# 関連Issue

なし

# 関連Pull Request

なし

# その他

なし
