### PR TITLE
ヘルスチェックの設定を追加

### DIFF
--- a/infrastructure/lib/constructs/ECS/index.ts
+++ b/infrastructure/lib/constructs/ECS/index.ts
@@ -61,7 +61,7 @@ export class ECS extends Construct {
     );
 
     albEcsService.targetGroup.configureHealthCheck({
-      path: "/sample?DATA1=1&DATA2=2&DATA3=3",
+      path: "/health_check",
       port: "8080",
     });
 

--- a/infrastructure/lib/constructs/ECS/index.ts
+++ b/infrastructure/lib/constructs/ECS/index.ts
@@ -60,6 +60,11 @@ export class ECS extends Construct {
       },
     );
 
+    albEcsService.targetGroup.configureHealthCheck({
+      path: "/sample?DATA1=1&DATA2=2&DATA3=3",
+      port: "8080",
+    });
+
     this.dnsName = albEcsService.loadBalancer.loadBalancerDnsName;
   }
 

--- a/server/app/src/main/java/cobol4j/aws/web/HealthCheckController.java
+++ b/server/app/src/main/java/cobol4j/aws/web/HealthCheckController.java
@@ -1,0 +1,15 @@
+
+package cobol4j.aws.web;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/health_check")
+public class HealthCheckController {
+    @GetMapping
+    public HealthCheckRecord healthCheck() {
+        return new HealthCheckRecord("OK");
+    }
+}

--- a/server/app/src/main/java/cobol4j/aws/web/HealthCheckRecord.java
+++ b/server/app/src/main/java/cobol4j/aws/web/HealthCheckRecord.java
@@ -1,0 +1,4 @@
+package cobol4j.aws.web;
+
+public record HealthCheckRecord(String message) {
+}


### PR DESCRIPTION
# 概要

ヘルス用のエンドポイントを作成し、ALBのヘルスチェックの設定を追加

# 変更点

- Spring bootのコードを変更し、/health_checkで常に`{"message": "OK"}`を返信するように変更
- ALBのヘルスチェックを/health_checkに向けるように設定

# 影響範囲

ヘルスチェックが成功することにより、スタック全体が正常にデプロイされるようになる

# テスト

なし

# 関連Issue

なし

# 関連Pull Request

なし

# その他

なし